### PR TITLE
Support switching between mock and simulator APIs

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes 1;
 error_log logs/error.log debug;
 
 events {
@@ -6,20 +6,33 @@ events {
 }
 
 http {
-
-  # load balancing across specs servers
-  upstream specs_servers {
+  # load balancing across simulator specs servers
+  upstream simulator_specs_servers {
     server frontend-simulator-1:8089;
     # fails over to the next one if not up, complains if not up at startup but works anyway
     #server frontend-simulator-2:8089;
   }
 
-  # load balancing across metrics servers
-  upstream metrics_servers {
+  # load balancing across simulator metrics servers
+  upstream simulator_metrics_servers {
     server frontend-simulator-1:8088;
     # fails over to the next one if not up, complains if not up at startup but works anyway
     #server frontend-simulator-2:8089;
   }
+
+  # load balancing across mock specs servers
+  upstream mock_specs_servers {
+    server frontend-dev-1:8089;
+    # fails over to the next one if not up, complains if not up at startup but works anyway
+    #server frontend-dev-2:8089;
+  }
+
+  # load balancing across mock metrics servers
+  upstream mock_metrics_servers {
+    server frontend-dev-1:8088;
+    # fails over to the next one if not up, complains if not up at startup but works anyway
+    #server frontend-dev-2:8089;
+  }  
 
   server {
     listen       8081;
@@ -49,55 +62,92 @@ http {
     # Ember
     # -----
     location / {
-     proxy_http_version  1.1;
-     proxy_set_header    Upgrade $http_upgrade;
-     proxy_set_header    Connection "upgrade";
-     proxy_set_header    Host            $host;
-     proxy_set_header    X-Real-IP       $remote_addr;
-     proxy_set_header    X-Forwarded-for $remote_addr;
-     proxy_buffering     off;
-     proxy_read_timeout  386400;
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "upgrade";
+      proxy_set_header    Host            $host;
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-for $remote_addr;
+      proxy_buffering     off;
+      proxy_read_timeout  386400;
 
-     proxy_pass http://localhost:4200;
+      proxy_pass http://localhost:4200;
     }
 
-    # Specs
+    # Simulator Specs
     # -----
-    location /api/vps/v1/specs {
-     access_by_lua_file "checkToken.lua";
+    location /api/vps/v1/simulator/specs {
+      access_by_lua_file "checkToken.lua";
 
-     rewrite /api/vps/v1/specs/(.*)$ /vps/v1/$1 break;
+      rewrite /api/vps/v1/simulator/specs/(.*)$ /vps/v1/$1 break;
 
-     proxy_http_version  1.1;
-     proxy_set_header    Upgrade $http_upgrade;
-     proxy_set_header    Connection "upgrade";
-     proxy_set_header    Host            $host;
-     proxy_set_header    X-Real-IP       $remote_addr;
-     proxy_set_header    X-Forwarded-for $remote_addr;
-     proxy_buffering     off;
-     proxy_read_timeout  386400;
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "upgrade";
+      proxy_set_header    Host            $host;
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-for $remote_addr;
+      proxy_buffering     off;
+      proxy_read_timeout  386400;
 
-     proxy_pass http://specs_servers;
+      proxy_pass http://simulator_specs_servers;
     }
 
-    # Metrics
+    # Simulator Metrics
     # -----
-    location /api/vps/v1/metrics {
-     access_by_lua_file "checkToken.lua";
+    location /api/vps/v1/simulator/metrics {
+      access_by_lua_file "checkToken.lua";
 
-     rewrite /api/vps/v1/metrics/(.*)$ /vps/v1/$1 break;
+      rewrite /api/vps/v1/simulator/metrics/(.*)$ /vps/v1/$1 break;
 
-     proxy_http_version  1.1;
-     proxy_set_header    Upgrade $http_upgrade;
-     proxy_set_header    Connection "upgrade";
-     proxy_set_header    Host            $host;
-     proxy_set_header    X-Real-IP       $remote_addr;
-     proxy_set_header    X-Forwarded-for $remote_addr;
-     proxy_buffering     off;
-     proxy_read_timeout  386400;
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "upgrade";
+      proxy_set_header    Host            $host;
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-for $remote_addr;
+      proxy_buffering     off;
+      proxy_read_timeout  386400;
 
-     proxy_pass http://metrics_servers;
+      proxy_pass http://simulator_metrics_servers;
     }
 
+    # Mock Specs
+    # -----
+    location /api/vps/v1/mock/specs {
+      access_by_lua_file "checkToken.lua";
+
+      rewrite /api/vps/v1/mock/specs/(.*)$ /vps/v1/$1 break;
+
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "upgrade";
+      proxy_set_header    Host            $host;
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-for $remote_addr;
+      proxy_buffering     off;
+      proxy_read_timeout  386400;
+
+      proxy_pass http://mock_specs_servers;
+    }
+
+    # Mock Metrics
+    # -----
+    location /api/vps/v1/mock/metrics {
+      access_by_lua_file "checkToken.lua";
+
+      rewrite /api/vps/v1/mock/metrics/(.*)$ /vps/v1/$1 break;
+
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "upgrade";
+      proxy_set_header    Host            $host;
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-for $remote_addr;
+      proxy_buffering     off;
+      proxy_read_timeout  386400;
+
+      proxy_pass http://mock_metrics_servers;
+    }    
   }
 }


### PR DESCRIPTION
`/api/vps/v1/simulator/specs`
`/api/vps/v1/simulator/metrics`
`/api/vps/v1/mock/specs`
`/api/vps/v1/mock/metrics`

@wangdrew 
